### PR TITLE
Add option for spacing between function parameters

### DIFF
--- a/docs/ClangFormatStyleOptions.rst
+++ b/docs/ClangFormatStyleOptions.rst
@@ -596,6 +596,9 @@ the configuration (without a prefix: ``Auto``).
   This does not affect trailing block comments (``/**/`` - comments) as those
   commonly have different usage patterns and a number of special cases.
 
+**SpacesBetweenFunctionParameters** (``bool``)
+  If ``true``, a space will be inserted between several function parameters.
+
 **SpacesInAngles** (``bool``)
   If ``true``, spaces will be inserted after '<' and before '>' in
   template argument lists

--- a/include/clang/Format/Format.h
+++ b/include/clang/Format/Format.h
@@ -529,6 +529,9 @@ struct FormatStyle {
   /// commonly have different usage patterns and a number of special cases.
   unsigned SpacesBeforeTrailingComments;
 
+  /// \b If \c true, spaces will be inserted between function parameters.
+  bool SpacesBetweenFunctionParameters;
+
   /// \brief If \c true, spaces will be inserted after '<' and before '>' in
   /// template argument lists
   bool SpacesInAngles;
@@ -609,8 +612,7 @@ struct FormatStyle {
            BreakBeforeTernaryOperators == R.BreakBeforeTernaryOperators &&
            BreakConstructorInitializersBeforeComma ==
                R.BreakConstructorInitializersBeforeComma &&
-           BreakInheritanceBeforeComma == 
-               R.BreakInheritanceBeforeComma &&
+           BreakInheritanceBeforeComma == R.BreakInheritanceBeforeComma &&
            BreakAfterJavaFieldAnnotations == R.BreakAfterJavaFieldAnnotations &&
            ColumnLimit == R.ColumnLimit && CommentPragmas == R.CommentPragmas &&
            ConstructorInitializerAllOnOneLineOrOnePerLine ==
@@ -654,6 +656,8 @@ struct FormatStyle {
            SpaceBeforeParens == R.SpaceBeforeParens &&
            SpaceInEmptyParentheses == R.SpaceInEmptyParentheses &&
            SpacesBeforeTrailingComments == R.SpacesBeforeTrailingComments &&
+           SpacesBetweenFunctionParameters ==
+               R.SpacesBetweenFunctionParameters &&
            SpacesInAngles == R.SpacesInAngles &&
            SpacesInContainerLiterals == R.SpacesInContainerLiterals &&
            SpacesInCStyleCastParentheses == R.SpacesInCStyleCastParentheses &&

--- a/lib/Format/Format.cpp
+++ b/lib/Format/Format.cpp
@@ -308,6 +308,8 @@ template <> struct MappingTraits<FormatStyle> {
     IO.mapOptional("SpaceInEmptyParentheses", Style.SpaceInEmptyParentheses);
     IO.mapOptional("SpacesBeforeTrailingComments",
                    Style.SpacesBeforeTrailingComments);
+    IO.mapOptional("SpacesBetweenFunctionParameters",
+                   Style.SpacesBetweenFunctionParameters);
     IO.mapOptional("SpacesInAngles", Style.SpacesInAngles);
     IO.mapOptional("SpacesInContainerLiterals",
                    Style.SpacesInContainerLiterals);
@@ -506,6 +508,7 @@ FormatStyle getLLVMStyle() {
   LLVMStyle.ObjCSpaceBeforeProtocolList = true;
   LLVMStyle.PointerAlignment = FormatStyle::PAS_Right;
   LLVMStyle.SpacesBeforeTrailingComments = 1;
+  LLVMStyle.SpacesBetweenFunctionParameters = true;
   LLVMStyle.Standard = FormatStyle::LS_Cpp11;
   LLVMStyle.UseTab = FormatStyle::UT_Never;
   LLVMStyle.SpacesInParentheses = false;
@@ -551,6 +554,7 @@ FormatStyle getGoogleStyle(FormatStyle::LanguageKind Language) {
   GoogleStyle.ObjCSpaceBeforeProtocolList = false;
   GoogleStyle.PointerAlignment = FormatStyle::PAS_Left;
   GoogleStyle.SpacesBeforeTrailingComments = 2;
+  GoogleStyle.SpacesBetweenFunctionParameters = true;
   GoogleStyle.Standard = FormatStyle::LS_Auto;
 
   GoogleStyle.PenaltyReturnTypeOnItsOwnLine = 200;

--- a/lib/Format/TokenAnnotator.cpp
+++ b/lib/Format/TokenAnnotator.cpp
@@ -2011,7 +2011,7 @@ bool TokenAnnotator::spaceRequiredBefore(const AnnotatedLine &Line,
       Left.isOneOf(TT_TrailingReturnArrow, TT_LambdaArrow))
     return true;
   if (Left.is(tok::comma))
-    return true;
+    return Style.SpacesBetweenFunctionParameters;
   if (Right.is(tok::comma))
     return false;
   if (Right.isOneOf(TT_CtorInitializerColon, TT_ObjCBlockLParen))

--- a/unittests/Format/FormatTest.cpp
+++ b/unittests/Format/FormatTest.cpp
@@ -10701,6 +10701,17 @@ TEST_F(FormatTest, SpacesInAngles) {
   verifyFormat("A<A<int>>();", Spaces);
 }
 
+TEST_F(FormatTest, SpacesBetweenFunctionParameters) {
+  FormatStyle Spaces = getLLVMStyle();
+  Spaces.SpacesBetweenFunctionParameters = false;
+
+  verifyFormat("void foo(int a,double b);", Spaces);
+  verifyFormat("void foo(int a,double b,char c);", Spaces);
+
+  verifyFormat("void foo(int a, double b);", Spaces);
+  verifyFormat("void foo(int a, double b, char c);", Spaces);
+}
+
 TEST_F(FormatTest, TripleAngleBrackets) {
   verifyFormat("f<<<1, 1>>>();");
   verifyFormat("f<<<1, 1, 1, s>>>();");


### PR DESCRIPTION
This patch adds an option to remove the blank after comma between several
function parameters. The default value is still to keep the blank.

Turns out the clang guys won't allow to get their "official" clang-format options polluted. Therefore I'm committing my contributions to this repo instead.
